### PR TITLE
Refactor: Use enum to Flag controls

### DIFF
--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -47,20 +47,4 @@ impl Flag {
     pub fn is_equal(&self, flag: &str) -> bool {
         self.as_str() == flag
     }
-
-    pub fn is_src(flag: &str) -> bool {
-        Flag::Src.is_equal(flag)
-    }
-
-    pub fn is_out_dir(flag: &str) -> bool {
-        Flag::OutDir.is_equal(flag)
-    }
-
-    pub fn is_name(flag: &str) -> bool {
-        Flag::Name.is_equal(flag)
-    }
-
-    pub fn is_platform(flag: &str) -> bool {
-        Flag::Platform.is_equal(flag)
-    }
 }

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -6,7 +6,7 @@ pub enum Flag {
 }
 
 impl Flag {
-    pub fn from_str(flag_str: &String) -> Option<Flag> {
+    pub fn from_str(flag_str: &str) -> Option<Flag> {
         if Flag::Src.is_equal(flag_str) {
             return Some(Flag::Src);
         }
@@ -44,23 +44,23 @@ impl Flag {
         ];
     }
 
-    pub fn is_equal(&self, flag: &String) -> bool {
+    pub fn is_equal(&self, flag: &str) -> bool {
         self.as_str() == flag
     }
 
-    pub fn is_src(flag: &String) -> bool {
+    pub fn is_src(flag: &str) -> bool {
         Flag::Src.is_equal(flag)
     }
 
-    pub fn is_out_dir(flag: &String) -> bool {
+    pub fn is_out_dir(flag: &str) -> bool {
         Flag::OutDir.is_equal(flag)
     }
 
-    pub fn is_name(flag: &String) -> bool {
+    pub fn is_name(flag: &str) -> bool {
         Flag::Name.is_equal(flag)
     }
 
-    pub fn is_platform(flag: &String) -> bool {
+    pub fn is_platform(flag: &str) -> bool {
         Flag::Platform.is_equal(flag)
     }
 }

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -7,23 +7,13 @@ pub enum Flag {
 
 impl Flag {
     pub fn from_str(flag_str: &str) -> Option<Flag> {
-        if Flag::Src.is_equal(flag_str) {
-            return Some(Flag::Src);
+        match flag_str {
+            s if Flag::Src.is_equal(s) => Some(Flag::Src),
+            s if Flag::OutDir.is_equal(s) => Some(Flag::OutDir),
+            s if Flag::Name.is_equal(s) => Some(Flag::Name),
+            s if Flag::Platform.is_equal(s) => Some(Flag::Platform),
+            _ => None,
         }
-
-        if Flag::OutDir.is_equal(flag_str) {
-            return Some(Flag::OutDir);
-        }
-
-        if Flag::Name.is_equal(flag_str) {
-            return Some(Flag::Name);
-        }
-
-        if Flag::Platform.is_equal(flag_str) {
-            return Some(Flag::Platform);
-        }
-
-        None
     }
 
     pub fn as_str(&self) -> &'static str {

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -8,10 +8,10 @@ pub enum Flag {
 impl Flag {
     pub fn from_str(flag_str: &str) -> Option<Flag> {
         match flag_str {
-            s if Flag::Src.is_equal(s) => Some(Flag::Src),
-            s if Flag::OutDir.is_equal(s) => Some(Flag::OutDir),
-            s if Flag::Name.is_equal(s) => Some(Flag::Name),
-            s if Flag::Platform.is_equal(s) => Some(Flag::Platform),
+            "--src" => Some(Flag::Src),
+            "--outDir" => Some(Flag::OutDir),
+            "--name" => Some(Flag::Name),
+            "--platform" => Some(Flag::Platform),
             _ => None,
         }
     }
@@ -32,9 +32,5 @@ impl Flag {
             Flag::Name.as_str(),
             Flag::Platform.as_str(),
         ]
-    }
-
-    pub fn is_equal(&self, flag: &str) -> bool {
-        self.as_str() == flag
     }
 }

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -35,13 +35,13 @@ impl Flag {
         }
     }
 
-    pub fn get_all_required() -> [&'static str; 4] {
-        return [
+    pub fn get_all_required() -> Vec<&'static str> {
+        vec![
             Flag::Src.as_str(),
             Flag::OutDir.as_str(),
             Flag::Name.as_str(),
             Flag::Platform.as_str(),
-        ];
+        ]
     }
 
     pub fn is_equal(&self, flag: &str) -> bool {

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -1,0 +1,66 @@
+pub enum Flag {
+    Src,
+    OutDir,
+    Name,
+    Platform,
+}
+
+impl Flag {
+    pub fn from_str(flag_str: &String) -> Option<Flag> {
+        if Flag::Src.is_equal(flag_str) {
+            return Some(Flag::Src);
+        }
+
+        if Flag::OutDir.is_equal(flag_str) {
+            return Some(Flag::OutDir);
+        }
+
+        if Flag::Name.is_equal(flag_str) {
+            return Some(Flag::Name);
+        }
+
+        if Flag::Platform.is_equal(flag_str) {
+            return Some(Flag::Platform);
+        }
+
+        None
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Flag::Src => "--src",
+            Flag::OutDir => "--outDir",
+            Flag::Name => "--name",
+            Flag::Platform => "--platform",
+        }
+    }
+
+    pub fn get_all_required() -> [&'static str; 4] {
+        return [
+            Flag::Src.as_str(),
+            Flag::OutDir.as_str(),
+            Flag::Name.as_str(),
+            Flag::Platform.as_str(),
+        ];
+    }
+
+    pub fn is_equal(&self, flag: &String) -> bool {
+        self.as_str() == flag
+    }
+
+    pub fn is_src(flag: &String) -> bool {
+        Flag::Src.is_equal(flag)
+    }
+
+    pub fn is_out_dir(flag: &String) -> bool {
+        Flag::OutDir.is_equal(flag)
+    }
+
+    pub fn is_name(flag: &String) -> bool {
+        Flag::Name.is_equal(flag)
+    }
+
+    pub fn is_platform(flag: &String) -> bool {
+        Flag::Platform.is_equal(flag)
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,14 +1,9 @@
+pub mod flag;
+use flag::Flag;
+
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
-
-pub const FLAG_SRC: &'static str = "--src";
-pub const FLAG_OUTDIR: &'static str = "--outDir";
-pub const FLAG_NAME: &'static str = "--name";
-pub const FLAG_PLATFORM: &'static str = "--platform";
-
-// Possible arguments for configuration
-const POSSIBLE_FLAGS: &'static [&'static str] = &[FLAG_SRC, FLAG_OUTDIR, FLAG_NAME, FLAG_PLATFORM];
 
 pub fn get_arguments() -> Result<HashMap<String, String>, String> {
     let args: Vec<String> = env::args().collect();
@@ -21,7 +16,6 @@ pub fn get_arguments() -> Result<HashMap<String, String>, String> {
 /// Returns an error if the arguments are not valid.
 fn load_args(args: Vec<String>) -> Result<HashMap<String, String>, String> {
     let args_number = get_args_number(&args);
-
     let mut setting = HashMap::new();
 
     for i in 1..(args_number + 1) {
@@ -43,9 +37,9 @@ fn load_args(args: Vec<String>) -> Result<HashMap<String, String>, String> {
         setting.insert((*argkey).to_string(), (*argvalue).to_string());
     }
 
-    for &argkey in POSSIBLE_FLAGS {
-        if setting.get(argkey) == None {
-            return Err(format!(r#""{}" argument not informed"#, argkey).to_string());
+    for flag in Flag::get_all_required() {
+        if setting.get(flag) == None {
+            return Err(format!(r#""{}" argument not informed"#, flag).to_string());
         }
     }
 
@@ -57,29 +51,23 @@ fn get_args_number(args: &[String]) -> u8 {
 }
 
 fn is_argkey_valid(argkey: &String) -> bool {
-    for arg in POSSIBLE_FLAGS {
-        if argkey.eq(*arg) {
-            return true;
-        }
-    }
-
-    false
+    Flag::from_str(argkey).is_some()
 }
 
 fn is_argvalue_valid(argkey: &String, argvalue: &String) -> bool {
-    if argkey == FLAG_SRC {
+    if Flag::is_src(argkey) {
         if !Path::new(argvalue).is_file() || !is_path_imagefile(argvalue) {
             return false;
         }
     }
 
-    if argkey == FLAG_OUTDIR {
+    if Flag::is_out_dir(argkey) {
         if !Path::new(argvalue).is_dir() {
             return false;
         }
     }
 
-    if argkey == FLAG_PLATFORM {
+    if Flag::is_platform(argkey) {
         if argvalue != "android" && argvalue != "flutter" {
             return false;
         }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -55,25 +55,13 @@ fn is_argkey_valid(argkey: &String) -> bool {
 }
 
 fn is_argvalue_valid(argkey: &String, argvalue: &String) -> bool {
-    if Flag::is_src(argkey) {
-        if !Path::new(argvalue).is_file() || !is_path_imagefile(argvalue) {
-            return false;
-        }
+    match Flag::from_str(argkey) {
+        Some(Flag::Src) => Path::new(argvalue).is_file() && is_path_imagefile(argvalue),
+        Some(Flag::OutDir) => Path::new(argvalue).is_dir(),
+        Some(Flag::Platform) => argvalue == "android" || argvalue == "flutter",
+        Some(_) => true,
+        _ => false,
     }
-
-    if Flag::is_out_dir(argkey) {
-        if !Path::new(argvalue).is_dir() {
-            return false;
-        }
-    }
-
-    if Flag::is_platform(argkey) {
-        if argvalue != "android" && argvalue != "flutter" {
-            return false;
-        }
-    }
-
-    true
 }
 
 fn is_path_imagefile(argvalue: &String) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 extern crate image;
 
+use cli::flag::Flag;
 mod cli;
 mod platform;
 mod resize;
@@ -16,10 +17,10 @@ fn main() {
     if let Ok(setting) = result {
         println!("setting: {:?}", setting);
 
-        let src = setting.get(cli::FLAG_SRC).unwrap();
-        let out_dir = setting.get(cli::FLAG_OUTDIR).unwrap();
-        let platform_name = setting.get(cli::FLAG_PLATFORM).unwrap();
-        let name = setting.get(cli::FLAG_NAME).unwrap();
+        let src = setting.get(Flag::Src.as_str()).unwrap();
+        let out_dir = setting.get(Flag::OutDir.as_str()).unwrap();
+        let platform_name = setting.get(Flag::Platform.as_str()).unwrap();
+        let name = setting.get(Flag::Name.as_str()).unwrap();
 
         if let Ok(img) = image::open(src) {
             let img_resize = resize::Resize::new(img, name.to_string());


### PR DESCRIPTION
This PR refactors flag handling by replacing string constants with an enum-based approach. The changes improve type safety and maintainability by centralizing flag definitions and validation logic.

- Introduced a new Flag enum to replace string constants for command-line flags
- Replaced direct string constant usage with enum method calls throughout the codebase
- Consolidated flag validation logic into the new Flag implementation