### PR TITLE
docs: Add MIT license and update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,11 @@
 [package]
 name = "droidpi"
+description = "A command-line tool for resizing images to multiple screen densities for Flutter and native Android projects. Automates icon generation for improved mobile performance."
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
+authors = ["David Gaspar <davidgaspar.dev@gmail.com>"]
+repository = "https://github.com/davidgaspardev/droidpi"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,25 @@
+Copyright (c) 2021-2025 DroidPI
+
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This pull request adds important metadata to the project and introduces a license file, making the project more professional and ready for open source distribution. The main changes include updating the `Cargo.toml` manifest with descriptive fields and adding the MIT license.

Project metadata improvements:

* Added a project description, license type (`MIT`), author information, and repository URL to the `Cargo.toml` manifest to clarify project purpose and ownership.

Licensing:

* Introduced a new `LICENSE-MIT` file with the full MIT license text, officially licensing the project and clarifying usage permissions.