### PR TITLE
Feature/add drawable support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,9 @@ jobs:
           [ -f "output/android/mipmap-xxhdpi/launcher-icon.png" ] && echo "✅ Found xxhdpi file" || (echo "❌ Missing xxhdpi file" && exit 1)
           [ -f "output/android/mipmap-xxxhdpi/launcher-icon.png" ] && echo "✅ Found xxxhdpi file" || (echo "❌ Missing xxxhdpi file" && exit 1)
 
+      - name: Clean output Android
+        run: rm -rf output/android
+
       - name: Run CLI tool for Android (use drawable)
         run: |
           mkdir -p output/android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,27 @@ jobs:
           [ -f "output/android/mipmap-xhdpi/launcher-icon.png" ] && echo "✅ Found xhdpi file" || (echo "❌ Missing xhdpi file" && exit 1)
           [ -f "output/android/mipmap-xxhdpi/launcher-icon.png" ] && echo "✅ Found xxhdpi file" || (echo "❌ Missing xxhdpi file" && exit 1)
           [ -f "output/android/mipmap-xxxhdpi/launcher-icon.png" ] && echo "✅ Found xxxhdpi file" || (echo "❌ Missing xxxhdpi file" && exit 1)
+
+      - name: Run CLI tool for Android (use drawable)
+        run: |
+          mkdir -p output/android
+          ./target/release/droidpi --src input/test-icon.png --outDir output/android --platform android --name launcher-icon --use-drawable
+
+      - name: Check Android output files
+        run: |
+          count=$(find output/android -type f -name "launcher-icon.png" | wc -l)
+          echo "Found $count launcher-icon.png files for Android"
+
+          if [ "$count" -eq 5 ]; then
+            echo "✅ Exactly five launcher-icon.png files found for Android"
+          else
+            echo "❌ Expected 5 launcher-icon.png files for Android, found $count"
+            exit 1
+          fi
+
+          # Check Android directory structure
+          [ -f "output/android/drawable-mdpi/launcher-icon.png" ] && echo "✅ Found mdpi file" || (echo "❌ Missing mdpi file" && exit 1)
+          [ -f "output/android/drawable-hdpi/launcher-icon.png" ] && echo "✅ Found hdpi file" || (echo "❌ Missing hdpi file" && exit 1)
+          [ -f "output/android/drawable-xhdpi/launcher-icon.png" ] && echo "✅ Found xhdpi file" || (echo "❌ Missing xhdpi file" && exit 1)
+          [ -f "output/android/drawable-xxhdpi/launcher-icon.png" ] && echo "✅ Found xxhdpi file" || (echo "❌ Missing xxhdpi file" && exit 1)
+          [ -f "output/android/drawable-xxxhdpi/launcher-icon.png" ] && echo "✅ Found xxxhdpi file" || (echo "❌ Missing xxxhdpi file" && exit 1)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create `my_icon.png` for Flutter:
 
 ### For Android
 
-Create `my_icon.png` for Android:
+Create `my_icon.png` for Android (default: **mipmap** directories):
 
 ```bash
 .../mipmap-mdpi/my_icon.png
@@ -35,18 +35,30 @@ Create `my_icon.png` for Android:
 .../mipmap-xxxhdpi/my_icon.png
 ```
 
+**With `--use-drawable` flag:**  
+Creates images in **drawable** directories instead:
+
+```bash
+.../drawable-mdpi/my_icon.png
+.../drawable-hdpi/my_icon.png
+.../drawable-xhdpi/my_icon.png
+.../drawable-xxhdpi/my_icon.png
+.../drawable-xxxhdpi/my_icon.png
+```
+
 ## Usage
 
 To resize an image using DroiDPI, use the following command:
 
 ```bash
-droidpi --src <image_path> --outdir <directory_path> --name <image_name> --platform <flutter|android>
+droidpi --src <image_path> --outdir <directory_path> --name <image_name> --platform <flutter|android> [--use-drawable]
 ```
 
 - `<image_path>`: The path to the input image file.
 - `<directory_path>`: The base directory where the resized images will be stored. The different densities will be created as subdirectories within this base directory, according to the selected platform.
 - `<image_name>`: The desired name for the resized images. The resized images will be saved with this name.
 - `<platform>`: The target platform for which the images will be generated. Supported values: `flutter` or `android`.
+- `--use-drawable`: *(Android only, optional)* If present, output images to `drawable-*dpi` directories instead of `mipmap-*dpi`.
 
 ### Examples
 
@@ -54,8 +66,11 @@ droidpi --src <image_path> --outdir <directory_path> --name <image_name> --platf
 # For Flutter projects
 droidpi --src logo.png --outdir ./assets --name logo --platform flutter
 
-# For native Android projects
+# For native Android projects (default: mipmap)
 droidpi --src icon.png --outdir ./res --name ic_launcher --platform android
+
+# For native Android projects (using drawable directories)
+droidpi --src icon.png --outdir ./res --name ic_launcher --platform android --use-drawable
 ```
 
 ## What do I want to do with this?

--- a/src/cli/flag.rs
+++ b/src/cli/flag.rs
@@ -6,9 +6,10 @@ pub enum Flag {
     Platform,
     Version,
     Help,
+    UseDrawable,
 }
 
-const BOOLEAN_FLAGS: [Flag; 2] = [Flag::Version, Flag::Help];
+const BOOLEAN_FLAGS: [Flag; 3] = [Flag::Version, Flag::Help, Flag::UseDrawable];
 
 impl Flag {
     pub fn from_str(flag_str: &str) -> Option<Flag> {
@@ -19,6 +20,7 @@ impl Flag {
             "--platform" => Some(Flag::Platform),
             "--version" => Some(Flag::Version),
             "--help" => Some(Flag::Help),
+            "--use-drawable" => Some(Flag::UseDrawable),
             _ => None,
         }
     }
@@ -31,6 +33,7 @@ impl Flag {
             Flag::Platform => "--platform",
             Flag::Version => "--version",
             Flag::Help => "--help",
+            Flag::UseDrawable => "--use-drawable",
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,6 @@ fn main() {
                 println!("arguments: {:?}", ctx.args);
 
                 let src = ctx.get_arg_src();
-                let out_dir = ctx.get_arg_out_dir();
                 let platform_name = ctx.get_arg_platform();
                 let name = ctx.get_arg_name();
 
@@ -37,7 +36,7 @@ fn main() {
                     match platform::PlatformFactory::get_platform_resize(platform_name, img_resize)
                     {
                         Ok(platform_target) => {
-                            let result = platform_target.create_images(out_dir);
+                            let result = platform_target.create_images(&ctx);
 
                             if let Err(msg) = result {
                                 eprint!("{}", msg);

--- a/src/platform/android.rs
+++ b/src/platform/android.rs
@@ -1,4 +1,4 @@
-use crate::resize::Resize;
+use crate::{context::Context, resize::Resize};
 use std::{fs, io::ErrorKind};
 
 use super::Platform;
@@ -14,17 +14,23 @@ impl AndroidPlatform {
 }
 
 impl Platform for AndroidPlatform {
-    fn create_images(&self, out_dir: &str) -> Result<(), String> {
+    fn create_images(&self, ctx: &Context) -> Result<(), String> {
+        let out_dir = ctx.get_arg_out_dir();
+        let dir_base = if ctx.args.contains_key("--use-drawable") {
+            "drawable"
+        } else {
+            "mipmap"
+        };
+        let final_dir = format!("{}/{}", out_dir, dir_base);
+
         return match fs::create_dir_all(out_dir) {
             Ok(_) => {
-                self.resize.create_mdpi(&format!("{}/mipmap-mdpi", out_dir));
-                self.resize.create_hdpi(&format!("{}/mipmap-hdpi", out_dir));
+                self.resize.create_mdpi(&format!("{}-mdpi", final_dir));
+                self.resize.create_hdpi(&format!("{}-hdpi", final_dir));
+                self.resize.create_xhdpi(&format!("{}-xhdpi", final_dir));
+                self.resize.create_xxhdpi(&format!("{}-xxhdpi", final_dir));
                 self.resize
-                    .create_xhdpi(&format!("{}/mipmap-xhdpi", out_dir));
-                self.resize
-                    .create_xxhdpi(&format!("{}/mipmap-xxhdpi", out_dir));
-                self.resize
-                    .create_xxxhdpi(&format!("{}/mipmap-xxxhdpi", out_dir));
+                    .create_xxxhdpi(&format!("{}-xxxhdpi", final_dir));
 
                 Ok(())
             }

--- a/src/platform/flutter.rs
+++ b/src/platform/flutter.rs
@@ -1,5 +1,5 @@
 use super::Platform;
-use crate::resize::Resize;
+use crate::{context::Context, resize::Resize};
 use std::{fs, io::ErrorKind};
 
 pub struct FlutterPlatform {
@@ -13,7 +13,9 @@ impl FlutterPlatform {
 }
 
 impl Platform for FlutterPlatform {
-    fn create_images(&self, out_dir: &str) -> Result<(), String> {
+    fn create_images(&self, ctx: &Context) -> Result<(), String> {
+        let out_dir = ctx.get_arg_out_dir();
+
         return match fs::create_dir_all(out_dir) {
             Ok(_) => {
                 self.resize.create_mdpi(&format!("{}/1.5x", out_dir));

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -1,4 +1,4 @@
-use crate::resize::Resize;
+use crate::{context::Context, resize::Resize};
 
 mod android;
 mod flutter;
@@ -23,5 +23,5 @@ impl PlatformFactory {
 }
 
 pub trait Platform {
-    fn create_images(&self, out_dir: &str) -> Result<(), String>;
+    fn create_images(&self, ctx: &Context) -> Result<(), String>;
 }


### PR DESCRIPTION
This pull request adds support for a new `--use-drawable` flag to the CLI, refactors platform image creation to use the full context instead of just the output directory, and updates the Android image output logic to optionally use the `drawable` directory structure. The changes improve flexibility for Android image output and make the codebase more consistent in how context is passed to platform implementations.

### CLI Flag Support

* Added a new boolean flag `--use-drawable` to the CLI, updating the `Flag` enum, flag parsing, and flag listing logic in `src/cli/flag.rs`. [[1]](diffhunk://#diff-f39915fc069584bb963495f25ec2ee8bf62277afed5aa8b8e32776a7700f5603R9-R12) [[2]](diffhunk://#diff-f39915fc069584bb963495f25ec2ee8bf62277afed5aa8b8e32776a7700f5603R23) [[3]](diffhunk://#diff-f39915fc069584bb963495f25ec2ee8bf62277afed5aa8b8e32776a7700f5603R36)

### Platform Interface Refactor

* Changed the `Platform` trait and all its implementations (`AndroidPlatform`, `FlutterPlatform`) to accept a `Context` reference instead of just an output directory string, making platform logic more flexible and consistent. [[1]](diffhunk://#diff-400d698ddcd6e628e94d9c1f6dd3c0934b5aa5cf6a3eeb0c35c033d84f7df088L26-R26) [[2]](diffhunk://#diff-8a469f9184766b66e49647a75192f001ef549e5f6fcf8c98eb4fc23ce9e87e15L17-R33) [[3]](diffhunk://#diff-e13747c3894649c84ff9c961fd990c69a941eb7ee6dc813e70e2dff832c848c0L16-R18)

### Android Output Directory Logic

* Updated Android image creation to use either the `drawable` or `mipmap` directory based on the presence of the `--use-drawable` flag, and refactored output paths accordingly in `src/platform/android.rs`.

### Main Function Refactor

* Updated the main function to pass the full context to platform image creation, removing the direct call to `get_arg_out_dir` and simplifying argument handling. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL30) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL40-R39)

### Code Consistency

* Updated imports in platform modules to include `Context` for consistency. [[1]](diffhunk://#diff-8a469f9184766b66e49647a75192f001ef549e5f6fcf8c98eb4fc23ce9e87e15L1-R1) [[2]](diffhunk://#diff-e13747c3894649c84ff9c961fd990c69a941eb7ee6dc813e70e2dff832c848c0L2-R2) [[3]](diffhunk://#diff-400d698ddcd6e628e94d9c1f6dd3c0934b5aa5cf6a3eeb0c35c033d84f7df088L1-R1)