### PR TITLE
fix: Remove '--' unnecessary form message of missing required

### DIFF
--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -39,7 +39,7 @@ impl Context {
                 exit(1)
             }
             None => {
-                eprintln!("Missing required argument '{flag_str}'. Please provide it using '--{flag_str} <value>'.");
+                eprintln!("Missing required argument '{flag_str}'. Please provide it using '{flag_str} <value>'.");
                 exit(1)
             }
         }


### PR DESCRIPTION
This pull request makes a small change to the error message shown when a required argument is missing in the `Context` implementation. The message now omits the double dash prefix, making the usage instruction clearer for users.